### PR TITLE
RATIS-875. Bump the copyright year in the NOTICE of thirdparty

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,3 +1,3 @@
 Apache Ratis Thirdparty
 
-Copyright 2018 The Apache Software Foundation
+Copyright 2020 The Apache Software Foundation


### PR DESCRIPTION

Just a trivial year update in NOTICE file.