### PR TITLE
RATIS-1037. Remove flatbuffers from thirdparty.

### DIFF
--- a/misc/pom.xml
+++ b/misc/pom.xml
@@ -40,16 +40,6 @@
       <version>${shaded.grpc.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.flatbuffers</groupId>
-      <artifactId>flatbuffers-java</artifactId>
-      <version>${shaded.flatbuffers.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.flatbuffers</groupId>
-      <artifactId>flatbuffers-java-grpc</artifactId>
-      <version>${shaded.flatbuffers.version}</version>
-    </dependency>
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
       <version>${shaded.grpc.version}</version>
@@ -147,10 +137,6 @@
                 <relocation>
                   <pattern>io.grpc</pattern>
                   <shadedPattern>${ratis.thirdparty.shaded.prefix}.io.grpc</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.google.flatbuffers</pattern>
-                  <shadedPattern>${ratis.thirdparty.shaded.prefix}.com.google.flatbuffers</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>io.netty</pattern>

--- a/misc/src/main/appended-resources/META-INF/NOTICE
+++ b/misc/src/main/appended-resources/META-INF/NOTICE
@@ -21,9 +21,3 @@ Copyright 2014 The Netty Project
 This product bundles Gson which includes the following text:
 
 Copyright 2008 Google Inc.
-
----
-
-This product bundles flatbuffers-java which includes the following text:
-
-Copyright 2014 Google Inc.

--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,6 @@
     <shaded.netty.version>4.1.48.Final</shaded.netty.version>
     <!--Version of tcnative to be shaded -->
     <shaded.netty.tcnative.version>2.0.28.Final</shaded.netty.tcnative.version>
-    <!--Version of flatbuffers to be shaded -->
-    <shaded.flatbuffers.version>1.11.0</shaded.flatbuffers.version>
 
     <io.opencensus.version>0.21.0</io.opencensus.version>
     <ratis.thirdparty.shaded.prefix>org.apache.ratis.thirdparty</ratis.thirdparty.shaded.prefix>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1037

Revert "RATIS-969. Add flatbuffers to Ratis thirdparty."

This reverts commit 8c146817485f7f104ccac595ad346ffe09038435.