### PR TITLE
Ratis 1046. relocate native_epoll.so files correctly to allow use of native epoll on Linux servers

### DIFF
--- a/misc/pom.xml
+++ b/misc/pom.xml
@@ -232,7 +232,7 @@
             </goals>
             <configuration>
               <includeGroupIds>io.netty</includeGroupIds>
-              <includeArtifactIds>netty-tcnative-boringssl-static</includeArtifactIds>
+              <includeArtifactIds>netty-tcnative-boringssl-static, netty-all</includeArtifactIds>
               <includes>**/META-INF/native/*</includes>
               <outputDirectory>${project.build.directory}/classes/</outputDirectory>
               <overWriteReleases>true</overWriteReleases>
@@ -266,6 +266,14 @@
                 <fileSet>
                   <sourceFile>${project.build.directory}/classes/META-INF/native/libnetty_tcnative_osx_x86_64.jnilib</sourceFile>
                   <destinationFile>${project.build.directory}/classes/META-INF/native/lib${ratis.thirdparty.shaded.native.prefix}netty_tcnative_osx_x86_64.jnilib</destinationFile>
+                </fileSet>
+                <fileSet>
+                  <sourceFile>${project.build.directory}/classes/META-INF/native/libnetty_transport_native_epoll_x86_64.so</sourceFile>
+                  <destinationFile>${project.build.directory}/classes/META-INF/native/lib${ratis.thirdparty.shaded.native.prefix}netty_transport_native_epoll_x86_64.so</destinationFile>
+                </fileSet>
+                <fileSet>
+                  <sourceFile>${project.build.directory}/classes/META-INF/native/libnetty_transport_native_kqueue_x86_64.jnilib</sourceFile>
+                  <destinationFile>${project.build.directory}/classes/META-INF/native/lib${ratis.thirdparty.shaded.native.prefix}netty_transport_native_kqueue_x86_64.jnilib</destinationFile>
                 </fileSet>
               </fileSets>
             </configuration>

--- a/misc/pom.xml
+++ b/misc/pom.xml
@@ -40,6 +40,16 @@
       <version>${shaded.grpc.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.google.flatbuffers</groupId>
+      <artifactId>flatbuffers-java</artifactId>
+      <version>${shaded.flatbuffers.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.flatbuffers</groupId>
+      <artifactId>flatbuffers-java-grpc</artifactId>
+      <version>${shaded.flatbuffers.version}</version>
+    </dependency>
+    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
       <version>${shaded.grpc.version}</version>
@@ -137,6 +147,10 @@
                 <relocation>
                   <pattern>io.grpc</pattern>
                   <shadedPattern>${ratis.thirdparty.shaded.prefix}.io.grpc</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.flatbuffers</pattern>
+                  <shadedPattern>${ratis.thirdparty.shaded.prefix}.com.google.flatbuffers</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>io.netty</pattern>

--- a/misc/src/main/appended-resources/META-INF/NOTICE
+++ b/misc/src/main/appended-resources/META-INF/NOTICE
@@ -21,3 +21,9 @@ Copyright 2014 The Netty Project
 This product bundles Gson which includes the following text:
 
 Copyright 2008 Google Inc.
+
+---
+
+This product bundles flatbuffers-java which includes the following text:
+
+Copyright 2014 Google Inc.

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,8 @@
     <shaded.netty.version>4.1.48.Final</shaded.netty.version>
     <!--Version of tcnative to be shaded -->
     <shaded.netty.tcnative.version>2.0.28.Final</shaded.netty.tcnative.version>
+    <!--Version of flatbuffers to be shaded -->
+    <shaded.flatbuffers.version>1.11.0</shaded.flatbuffers.version>
 
     <io.opencensus.version>0.21.0</io.opencensus.version>
     <ratis.thirdparty.shaded.prefix>org.apache.ratis.thirdparty</ratis.thirdparty.shaded.prefix>


### PR DESCRIPTION


Netty jars provides native epoll which is better in performance over NIO. However because of netty shading, the .so files are not shaded correctly. This jira shades the jar's correctly.

https://netty.io/wiki/native-transports.html
