### PR TITLE
RATIS-1293. Add standard ending to thirdparty NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,3 +1,6 @@
 Apache Ratis Thirdparty
 
-Copyright 2020 The Apache Software Foundation
+Copyright 2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
As Justin Mclean reported during the 0.6.0 vote, this standard phrase is missing from the the thirdpardy NOTICE file:

```
This product includes software developed at
The Apache Software Foundation (http://www.apache.org/).
```
